### PR TITLE
List and retrieve destinations, flights and seats functionality

### DIFF
--- a/backend_system/authentication/permissions.py
+++ b/backend_system/authentication/permissions.py
@@ -1,0 +1,1 @@
+# users who do not have admin rights should be able to view their profiles only

--- a/backend_system/flights/urls.py
+++ b/backend_system/flights/urls.py
@@ -5,9 +5,17 @@ from flights import views
 
 urlpatterns = [
     url(r'^flights/$', views.FlightViewSet.as_view(
-        actions={'post': 'create'}), name='flight-list'),
+        actions={'post': 'create', 'get': 'list'}), name='flight-list'),
+    url(r'^flights/(?P<pk>[0-9]+)/$', views.FlightViewSet.as_view(
+        actions={'get': 'retrieve'}), name='flight-detail'),
     url(r'^allowed-destinations/$', views.LocationViewSet.as_view(
-        actions={'post': 'create'}), name='destination-list'),
+        actions={'post': 'create', 'get': 'list'}), name='destination-list'),
+    url(r'^allowed-destinations/(?P<pk>[0-9]+)/$', views.LocationViewSet.as_view(
+        actions={'get': 'retrieve'}),
+        name='destination-detail'),
     url(r'^flights/(?P<flight_pk>[0-9]+)/seats/$', views.SeatViewset.as_view(
-        actions={'post': 'create'}), name='flight-seat-list'),
+        actions={'post': 'create', 'get': 'list'}), name='flight-seat-list'),
+    url(r'^flights/(?P<flight_pk>[0-9]+)/seats/(?P<pk>[0-9]+)/$', views.SeatViewset.as_view(
+        actions={'get': 'retrieve'}),
+        name='flight-seat-detail'),
 ]


### PR DESCRIPTION
#### What does this PR do?
Adds functionality to allow all users to view:
- allowed destinations
- flights
- flight seats
 #### Description of the task done?
- add tests and view functionality
#### How should this be manually tested?
- cd backend_system
- python `manage.py test` to run tests
- python `manage.py show_urls` to view existing  and you can try out the urls
#### Relevant pivotal tracker story?
[#164328327](https://www.pivotaltracker.com/story/show/164328327)