### PR TITLE
Update and delete destinations, flights and seats functionality

### DIFF
--- a/backend_system/flights/urls.py
+++ b/backend_system/flights/urls.py
@@ -7,15 +7,15 @@ urlpatterns = [
     url(r'^flights/$', views.FlightViewSet.as_view(
         actions={'post': 'create', 'get': 'list'}), name='flight-list'),
     url(r'^flights/(?P<pk>[0-9]+)/$', views.FlightViewSet.as_view(
-        actions={'get': 'retrieve'}), name='flight-detail'),
+        actions={'get': 'retrieve', 'put': 'update', 'delete': 'destroy'}), name='flight-detail'),
     url(r'^allowed-destinations/$', views.LocationViewSet.as_view(
         actions={'post': 'create', 'get': 'list'}), name='destination-list'),
     url(r'^allowed-destinations/(?P<pk>[0-9]+)/$', views.LocationViewSet.as_view(
-        actions={'get': 'retrieve'}),
+        actions={'get': 'retrieve', 'put': 'update', 'delete': 'destroy'}),
         name='destination-detail'),
     url(r'^flights/(?P<flight_pk>[0-9]+)/seats/$', views.SeatViewset.as_view(
         actions={'post': 'create', 'get': 'list'}), name='flight-seat-list'),
     url(r'^flights/(?P<flight_pk>[0-9]+)/seats/(?P<pk>[0-9]+)/$', views.SeatViewset.as_view(
-        actions={'get': 'retrieve'}),
+        actions={'get': 'retrieve', 'put': 'update', 'delete': 'destroy'}),
         name='flight-seat-detail'),
 ]


### PR DESCRIPTION
#### What does this PR do?
- Adds functionality to allow all superusers to edit and delete flights, destinations and seats
 #### Description of the task done?
- add tests and view functionality
#### How should this be manually tested?
- cd backend_system
- python `manage.py test` to run tests
- python `manage.py show_urls` to view existing  and you can try out the urls
#### Relevant pivotal tracker story?
[#164327829](https://www.pivotaltracker.com/story/show/164327829)